### PR TITLE
Remove empty selectable option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,6 @@ export default class SelectPicker extends PureComponent {
 					});
 				}
 				return [
-					(index == 0) && (<PickerItemNative label={this.state.placeholder} value={null} />),
 					<PickerItemNative {...child.props} />
 				]
 			});


### PR DESCRIPTION
Hello. I think it is quite confusing and possible error-prone if you allow user to select an empty value. Do not know what is purpose of it but if you still want to keep and you do not accept this PR then we can include some conditional and add a prop to remove it as again it could produce bugs if we allow selecting null as a value.