### PR TITLE
Fixed disabled property issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,11 @@ export default class SelectPicker extends PureComponent {
 	}
 
 	showSelectModal = () => {
-		this.stateSet({
-			visible: true
-		});
+		if(!this.state.disabled){
+			this.stateSet({
+				visible: true
+			});
+		}
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
Hi,

Disabled option not working with `"react-native": "0.62.2"` and  `"react-native-form-select-picker": "0.0.9"`.

I examined it and saw that there is no "disabled" check on showSelectModal function.