### PR TITLE
Updated Deprecated import

### DIFF
--- a/src/components/picketitem-native.js
+++ b/src/components/picketitem-native.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Picker } from '@react-native-community/picker';
+import { Picker } from '@react-native-picker/picker';
 
 const PickerItemNative = (props) => {
     return <Picker.Item {...props} />

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { AppRegistry, View, Modal, TouchableOpacity, StyleSheet, ScrollView, Text, Platform } from 'react-native';
-import { Picker } from '@react-native-community/picker';
+import { Picker } from '@react-native-picker/picker';
 import PickerItem from './components/pickeritem';
 import PickerItemNative from './components/picketitem-native';
 import Logger from './utils/logger';


### PR DESCRIPTION
replaced
`import { Picker } from '@react-native-community/picker';`
by
`import { Picker } from '@react-native-picker/picker';`

since the package changed the name.